### PR TITLE
Simplify lock command to avoid MANAGE_ROLES permission

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -273,7 +273,7 @@ async def run_command_tests(bot: commands.Bot) -> dict[str, str]:
 def setup(bot: commands.Bot):
     @bot.tree.command(name="test", description="Test all commands")
     async def test_commands(inter: discord.Interaction):
-        if not has_command_permission(inter.user, "test", "admin"):
+        if not has_command_permission(inter.user, "test", "manage_guild"):
             await inter.response.send_message("No permission.", ephemeral=True)
             return
         await inter.response.defer(thinking=True, ephemeral=True)
@@ -292,7 +292,7 @@ def setup(bot: commands.Bot):
     @app_commands.describe(user="User")
     async def lastdate(interaction: discord.Interaction, user: discord.Member):
         if (
-            not has_command_permission(interaction.user, "lastdate", "admin")
+            not has_command_permission(interaction.user, "lastdate", "manage_guild")
             and not interaction.user.premium_since
         ):
             await interaction.response.send_message(
@@ -322,7 +322,7 @@ def setup(bot: commands.Bot):
         reference: discord.Role | None = None,
         above: bool = True,
     ):
-        if not has_command_permission(inter.user, "addshoprole", "admin"):
+        if not has_command_permission(inter.user, "addshoprole", "manage_roles"):
             await inter.response.send_message("No permission.", ephemeral=True)
             return
         try:
@@ -405,7 +405,7 @@ def setup(bot: commands.Bot):
         role: discord.Role,
     ):
         if not has_command_permission(
-            interaction.user, "addcolorreactionrole", "admin"
+            interaction.user, "addcolorreactionrole", "manage_roles"
         ):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
@@ -432,7 +432,7 @@ def setup(bot: commands.Bot):
     @app_commands.describe(user="User to imitate", msg="The message to send")
     async def imitate(interaction: discord.Interaction, user: discord.Member, msg: str):
         if (
-            not has_command_permission(interaction.user, "imitate", "admin")
+            not has_command_permission(interaction.user, "imitate", "manage_messages")
             and not interaction.user.premium_since
         ):
             await interaction.response.send_message(
@@ -465,7 +465,7 @@ def setup(bot: commands.Bot):
     async def giveaway(
         interaction: discord.Interaction, duration: int, prize: str, winners: int
     ):
-        if not has_command_permission(interaction.user, "giveaway", "admin"):
+        if not has_command_permission(interaction.user, "giveaway", "manage_guild"):
             await interaction.response.send_message(
                 "Only admins and owners can use this command", ephemeral=True
             )
@@ -507,30 +507,24 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="lock", description="Lock this channel (Admin only)")
     async def lock_channel(interaction: discord.Interaction):
-        if not has_command_permission(interaction.user, "lock", "admin"):
+        if not has_command_permission(interaction.user, "lock", "manage_channels"):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
-        lock_id = get_role(interaction.guild.id, "channel_lock")
-        role = interaction.guild.get_role(lock_id) if lock_id else None
-        if role is None:
-            await interaction.response.send_message("Role not found.", ephemeral=True)
-            return
-        await interaction.channel.set_permissions(role, send_messages=False)
+        await interaction.channel.set_permissions(
+            interaction.guild.default_role, send_messages=False
+        )
         await interaction.response.send_message(
             "\U0001f512 Channel locked.", ephemeral=True
         )
 
     @bot.tree.command(name="unlock", description="Unlock this channel (Admin only)")
     async def unlock_channel(interaction: discord.Interaction):
-        if not has_command_permission(interaction.user, "unlock", "admin"):
+        if not has_command_permission(interaction.user, "unlock", "manage_channels"):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
-        lock_id = get_role(interaction.guild.id, "channel_lock")
-        role = interaction.guild.get_role(lock_id) if lock_id else None
-        if role is None:
-            await interaction.response.send_message("Role not found.", ephemeral=True)
-            return
-        await interaction.channel.set_permissions(role, send_messages=True)
+        await interaction.channel.set_permissions(
+            interaction.guild.default_role, send_messages=None
+        )
         await interaction.response.send_message(
             "\U0001f513 Channel unlocked.", ephemeral=True
         )
@@ -748,13 +742,13 @@ def setup(bot: commands.Bot):
 
     @bot.tree.command(name="setrole", description="Configure a role used by the bot")
     @app_commands.describe(
-        name="Which role to configure (admin/mod/sheher/hehim)",
+        name="Which role to configure (sheher/hehim)",
         role="The role to use",
     )
     @app_commands.checks.has_permissions(manage_guild=True)
     async def setrole(interaction: discord.Interaction, name: str, role: discord.Role):
         key = name.lower()
-        valid = {"admin", "mod", "sheher", "hehim"}
+        valid = {"sheher", "hehim"}
         if key not in valid:
             await interaction.response.send_message(
                 "\u274c Invalid role name.", ephemeral=True
@@ -779,7 +773,7 @@ def setup(bot: commands.Bot):
     @app_commands.checks.has_permissions(manage_guild=True)
     async def removerole(interaction: discord.Interaction, name: str):
         key = name.lower()
-        valid = {"admin", "mod", "sheher", "hehim"}
+        valid = {"sheher", "hehim"}
         if key not in valid:
             await interaction.response.send_message(
                 "\u274c Invalid role name.", ephemeral=True

--- a/commands/stats_commands.py
+++ b/commands/stats_commands.py
@@ -287,7 +287,7 @@ def setup(bot: commands.Bot, shop: dict[int, tuple[int, float]]):
     async def addrod(
         interaction: discord.Interaction, level: int, price: int, multiplier: float
     ):
-        if not has_command_permission(interaction.user, "addrod", "admin"):
+        if not has_command_permission(interaction.user, "addrod", "manage_guild"):
             await interaction.response.send_message("No permission.", ephemeral=True)
             return
         rod_shop[level] = (price, multiplier)

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import discord
 from discord import ui
 from typing import Optional
-from db.DBHelper import get_command_permission, get_role
+from db.DBHelper import get_command_permission
 
 webhook_cache: dict[int, discord.Webhook] = {}
 
@@ -41,17 +41,17 @@ def has_role(member: discord.Member, role: int | str) -> bool:
 
 
 def has_command_permission(
-    user: discord.Member, command: str, fallback_role_key: str
+    user: discord.Member, command: str, required_permission: str
 ) -> bool:
     if user.guild and user.id == user.guild.owner_id:
         # The server owner always has access to every command.
         return True
+    if getattr(user.guild_permissions, required_permission, False):
+        return True
     role_id = get_command_permission(user.guild.id, command)
     if role_id is None:
-        role_id = get_role(user.guild.id, fallback_role_key)
-    if role_id is None:
         print(
-            f"[PERM] No role found for command={command}, fallback={fallback_role_key}"
+            f"[PERM] No role or permission for command={command}, perm={required_permission}"
         )
         return False
     print(


### PR DESCRIPTION
## Summary
- default command access uses corresponding Discord permissions before optional role override
- limit `/setrole` and `/removerole` to pronoun roles only
- map admin commands to specific permissions such as `manage_channels` for lock/unlock

## Testing
- `python -m py_compile commands/admin_commands.py commands/stats_commands.py utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48bdd97508327a7725664c961a813