### PR TITLE
Enable command selection for setcommandrole and show detailed errors

### DIFF
--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -798,12 +798,29 @@ def setup(bot: commands.Bot):
     )
     @app_commands.checks.has_permissions(manage_guild=True)
     async def setcommandrole(
-        interaction: discord.Interaction, command: str, role: discord.Role
+        interaction: discord.Interaction, command: str, role: discord.Role,
     ):
-        set_command_permission(interaction.guild.id, command, role.id)
+        cmd = bot.tree.get_command(command)
+        if cmd is None:
+            await interaction.response.send_message(
+                "Unknown command.", ephemeral=True
+            )
+            return
+        set_command_permission(interaction.guild.id, cmd.name, role.id)
         await interaction.response.send_message(
-            f"\u2705 Set {command} command role to {role.mention}.", ephemeral=True
+            f"\u2705 Set {cmd.name} command role to {role.mention}.",
+            ephemeral=True,
         )
+
+    @setcommandrole.autocomplete("command")
+    async def setcommandrole_autocomplete(
+        interaction: discord.Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        commands_list: list[app_commands.Choice[str]] = []
+        for c in bot.tree.get_commands():
+            if current.lower() in c.name.lower():
+                commands_list.append(app_commands.Choice(name=c.name, value=c.name))
+        return commands_list[:25]
 
     @bot.tree.command(
         name="removecommandrole", description="Remove required role for a command"

--- a/events.py
+++ b/events.py
@@ -328,7 +328,7 @@ async def on_app_error(bot: commands.Bot, inter: discord.Interaction, error: Exc
         )
         return
     logging.exception(f"Slash-command error {error_id}", exc_info=error)
-    msg = f"Oops, something went wrong 😵 (Error ID: {error_id})"
+    msg = f"Error: {error} (Error ID: {error_id})"
     if inter.response.is_done():
         await inter.followup.send(msg, ephemeral=True)
     else:
@@ -367,7 +367,7 @@ async def on_command_error(
     if log_ch and log_ch != central_log:
         await log_ch.send(embed=embed)
     logging.exception(f"Prefix command error {error_id}", exc_info=error)
-    await ctx.send(f"Oops, something went wrong 😵 (Error ID: {error_id})")
+    await ctx.send(f"Error: {error} (Error ID: {error_id})")
 
 
 def format_options(data: dict, interaction: discord.Interaction) -> str:


### PR DESCRIPTION
## Summary
- allow `/setcommandrole` to autocomplete available commands and validate input
- show underlying error message with ID for slash and prefix commands

## Testing
- `python -m py_compile commands/admin_commands.py events.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49e31d5088327ae8b9b4999fc6665