### PR TITLE
Fix owner bypass for command permissions

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -43,12 +43,15 @@ def has_role(member: discord.Member, role: int | str) -> bool:
 def has_command_permission(
     user: discord.Member, command: str, required_permission: str
 ) -> bool:
-    if user.guild and user.id == user.guild.owner_id:
+    guild = getattr(user, "guild", None)
+    if guild is not None and user.id == guild.owner_id:
         # The server owner always has access to every command.
         return True
     if getattr(user.guild_permissions, required_permission, False):
         return True
-    role_id = get_command_permission(user.guild.id, command)
+    if guild is None:
+        return False
+    role_id = get_command_permission(guild.id, command)
     if role_id is not None:
         print(
             f"[PERM] Required role_id: {role_id}, user roles: {[r.id for r in user.roles]}"
@@ -69,7 +72,7 @@ async def ensure_command_permission(
     """Check command permission and notify user if missing."""
     user = interaction.user
     guild = interaction.guild
-    if user.guild and user.id == guild.owner_id:
+    if guild is not None and user.id == guild.owner_id:
         return True
     role_id = get_command_permission(guild.id, command)
     if role_id is not None:


### PR DESCRIPTION
## Summary
- fix owner permission check by avoiding boolean evaluation of `Guild`
- ensure command permission helper handles missing guild gracefully

## Testing
- `python -m py_compile utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9eaf8367c8327a0e9523e293e063f