### PR TITLE
Ensure compatibility with older Python versions

### DIFF
--- a/anti_nuke.py
+++ b/anti_nuke.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord.ext import commands
 from datetime import timedelta

--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord.ext import commands
 

--- a/commands/action_commands.py
+++ b/commands/action_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands
 from discord.ext import commands

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import inspect
 import io
@@ -130,7 +132,7 @@ async def run_command_tests(bot: commands.Bot) -> dict[str, str]:
                     self,
                     user_id: int = 0,
                     name: str = "tester",
-                    guild: DummyGuild | None = None,
+                    guild: Optional[DummyGuild] = None,
                 ):
 
                     self.id = user_id
@@ -320,7 +322,7 @@ def setup(bot: commands.Bot):
         name: str,
         price: int,
         color: str,
-        reference: discord.Role | None = None,
+        reference: Optional[discord.Role] = None,
         above: bool = True,
     ):
 
@@ -856,10 +858,10 @@ def setup(bot: commands.Bot):
         role_name: str,
         role_color: str,
         member1: discord.Member,
-        member2: discord.Member | None = None,
-        member3: discord.Member | None = None,
-        member4: discord.Member | None = None,
-        member5: discord.Member | None = None,
+        member2: Optional[discord.Member] = None,
+        member3: Optional[discord.Member] = None,
+        member4: Optional[discord.Member] = None,
+        member5: Optional[discord.Member] = None,
     ):
         allowed_usernames = {"goodyb", "nannapat2410"}
         if interaction.user.name.lower() not in allowed_usernames:

--- a/commands/antinuke_commands.py
+++ b/commands/antinuke_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands
 from discord.ext import commands

--- a/commands/booster_commands.py
+++ b/commands/booster_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands
 from discord.ext import commands

--- a/commands/economy_commands.py
+++ b/commands/economy_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 
 import discord
@@ -6,6 +8,7 @@ from discord.ext import commands
 from datetime import datetime, timedelta
 from random import random, choice, shuffle
 from collections import Counter
+from typing import Optional
 
 CARD_DECK: list[tuple[str, int]] = []
 _rank_codes = [
@@ -224,8 +227,8 @@ class RPSView(ui.View):
         self.p1_id = p1_id
         self.p2_id = p2_id
         self.bet = bet
-        self.choices: dict[int, str | None] = {p1_id: None, p2_id: None}
-        self.message: discord.Message | None = None
+        self.choices: dict[int, Optional[str]] = {p1_id: None, p2_id: None}
+        self.message: Optional[discord.Message] = None
 
     async def _choose(self, interaction: discord.Interaction, choice: str):
         if interaction.user.id not in self.choices:
@@ -246,7 +249,7 @@ class RPSView(ui.View):
     async def _finish(self):
         c1 = self.choices[self.p1_id]
         c2 = self.choices[self.p2_id]
-        winner: int | None = None
+        winner: Optional[int] = None
         if c1 != c2:
             beats = {"rock": "scissors", "scissors": "paper", "paper": "rock"}
             if beats[c1] == c2:
@@ -293,7 +296,7 @@ class BlackjackView(ui.View):
         self.bet = bet
         self.player = [self._draw(), self._draw()]
         self.dealer = [self._draw(), self._draw()]
-        self.message: discord.Message | None = None
+        self.message: Optional[discord.Message] = None
         self.finished = False
 
     def _draw(self) -> tuple[str, int]:
@@ -402,7 +405,7 @@ class PokerJoinView(ui.View):
         self.bot = bot
         self.bet = bet
         self.players: dict[int, str] = {host_id: ""}
-        self.message: discord.Message | None = None
+        self.message: Optional[discord.Message] = None
 
     def render(self) -> str:
         joined = " ".join(f"<@{pid}>" for pid in self.players)

--- a/commands/explain_commands.py
+++ b/commands/explain_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands
 from discord.ext import commands

--- a/commands/fun_commands.py
+++ b/commands/fun_commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands
 from discord.ext import commands

--- a/commands/setup_wizard.py
+++ b/commands/setup_wizard.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Union
 

--- a/commands/stats_commands.py
+++ b/commands/stats_commands.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands
 from discord.ext import commands
+from typing import Optional
 from datetime import datetime, timedelta
 from random import choice, randint, random
 from config import (
@@ -51,7 +54,7 @@ def setup(bot: commands.Bot, shop: dict[int, tuple[int, float]]):
 
     @bot.tree.command(name="stats", description="Show your stats & unspent points")
     async def stats_cmd(
-        interaction: discord.Interaction, user: discord.Member | None = None
+        interaction: discord.Interaction, user: Optional[discord.Member] = None
     ):
         target = user or interaction.user
         register_user(str(target.id), target.display_name)
@@ -333,7 +336,7 @@ def setup(bot: commands.Bot, shop: dict[int, tuple[int, float]]):
 
     @bot.tree.command(name="myrod", description="Show your fishing rod")
     async def myrod(
-        interaction: discord.Interaction, user: discord.Member | None = None
+        interaction: discord.Interaction, user: Optional[discord.Member] = None
     ):
         target = user or interaction.user
         register_user(str(target.id), target.display_name)

--- a/config.py
+++ b/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 DB_PATH = "users.db"
 DAILY_REWARD = 20
 STAT_PRICE = 66

--- a/db/DBHelper.py
+++ b/db/DBHelper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sqlite3
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
@@ -129,7 +131,9 @@ def get_stats(user_id: str):
         (user_id,),
     )
     if not row:
-        return {s: 1 for s in STAT_NAMES} | {"stat_points": 0}
+        stats = {s: 1 for s in STAT_NAMES}
+        stats["stat_points"] = 0
+        return stats
     return dict(zip(STAT_NAMES + ["stat_points"], row))
 
 

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sqlite3
 from config import DB_PATH
 

--- a/events.py
+++ b/events.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from datetime import datetime, timezone, timedelta

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import discord
 from discord import app_commands, ui
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 webhook_cache: dict[int, discord.Webhook] = {}
 
@@ -31,7 +33,7 @@ def parse_duration(duration: str) -> Optional[int]:
         return None
 
 
-def has_role(member: discord.Member, role: int | str) -> bool:
+def has_role(member: discord.Member, role: Union[int, str]) -> bool:
     if member.name == "goodyb":
         return True
     if isinstance(role, int):
@@ -39,7 +41,7 @@ def has_role(member: discord.Member, role: int | str) -> bool:
     return any(r.name == role for r in member.roles)
 
 
-def _is_guild_owner(user: discord.abc.User, guild: discord.Guild | None) -> bool:
+def _is_guild_owner(user: discord.abc.User, guild: Optional[discord.Guild]) -> bool:
     """Return True if the user owns the given guild."""
     if guild is None:
         return False
@@ -87,7 +89,11 @@ async def ensure_command_permission(
     return False
 
 
-def command_requires(required_permission: str, *, bypass: Callable[[discord.Interaction], bool] | None = None):
+def command_requires(
+    required_permission: str,
+    *,
+    bypass: Optional[Callable[[discord.Interaction], bool]] = None,
+):
     """Decorator enforcing Discord permissions on app commands."""
 
     async def predicate(interaction: discord.Interaction) -> bool:


### PR DESCRIPTION
## Summary
- Prevent runtime type errors by deferring annotation evaluation across modules
- Replace Python 3.10+ union syntax with typing equivalents
- Remove dictionary union operator for broader Python support

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b1a03e93b08327b7762b688d9dcc16