### PR TITLE
Start webhook server automatically and use env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ The wizard explains every step, lets you skip anything, and sets up channels
 and anti-nuke options. For role shortcuts and command restrictions it points
 you to the `/setrole` and `/setcommandrole` commands for later use.
 
+## Environment variables
+
+The bot and the Top.gg webhook server rely on the following environment variables:
+
+* `DISCORD_TOKEN` – Discord bot token.
+* `TOPGG_AUTH` – token used to validate incoming Top.gg votes.
+* `PORT` – optional port for the webhook server (defaults to 80).
+
+Example start command:
+
+```bash
+export DISCORD_TOKEN=<your_token>
+export TOPGG_AUTH=<topgg_webhook_token>
+python bot.py
+```
+
+`bot.py` automatically launches `server.js` so the webhook is ready whenever the bot runs.
+

--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import subprocess
+
 import discord
 from discord.ext import commands
 
@@ -36,8 +39,16 @@ setup_explain(bot)
 events.setup(bot, lowercase_locked)
 anti_nuke.setup(bot)
 
+# Read the Discord token from an environment variable
+TOKEN = os.getenv("DISCORD_TOKEN")
+if not TOKEN:
+    raise RuntimeError("DISCORD_TOKEN environment variable not set")
 
-with open("code.txt", "r") as file:
-    TOKEN = file.read().strip()
+# Start the top.gg webhook server (Node.js) alongside the bot
+node_proc = subprocess.Popen(["node", "server.js"])
 
-bot.run(TOKEN)
+try:
+    bot.run(TOKEN)
+finally:
+    node_proc.terminate()
+    node_proc.wait()

--- a/server.js
+++ b/server.js
@@ -1,11 +1,12 @@
 const express = require("express");
-const bodyParser = require("body-parser");
 const app = express();
-const PORT = 80;                 // oder 443 mit HTTPS
 
-const TOPGG_AUTH = "lS6lvCvcDdDKklWoUHLLjtz10g0eZCW8"; // exakt derselbe Token wie auf top.gg
+// Allow port/token to be configured through environment variables.
+const PORT = process.env.PORT || 80; // oder 443 mit HTTPS
+const TOPGG_AUTH = process.env.TOPGG_AUTH; // exakt derselbe Token wie auf top.gg
 
-app.use(bodyParser.json());
+// Express has built-in JSON body parsing.
+app.use(express.json());
 
 app.post("/vote", (req, res) => {
     const auth = req.header("Authorization");


### PR DESCRIPTION
## Summary
- Read webhook port and token from environment variables and drop body-parser in favor of `express.json`
- Launch the Node webhook server from `bot.py` and fetch Discord token from `DISCORD_TOKEN`
- Document required environment variables for the bot and webhook server

## Testing
- `node --check server.js`
- `python -m py_compile bot.py`
- `npm install express` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a6e349f48327895182dc887d4329