### PR TITLE
Award coins for Top.gg votes and add vote command

### DIFF
--- a/commands/economy_commands.py
+++ b/commands/economy_commands.py
@@ -482,6 +482,13 @@ async def start_poker_game(
 
 
 def setup(bot: commands.Bot):
+    @bot.tree.command(name="vote", description="Get the Top.gg vote link")
+    async def vote(interaction: discord.Interaction):
+        await interaction.response.send_message(
+            "Vote for the bot and earn coins!\nhttps://top.gg/bot/1401961800504971316/vote",
+            ephemeral=True,
+        )
+
     @bot.tree.command(name="money", description="Check your clubhall coin balance")
     async def money(interaction: discord.Interaction):
         user_id = str(interaction.user.id)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "publishedclubhallbot",
+  "version": "1.0.0",
+  "description": "Utility bot for Discord.",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/scripts/award_vote.py
+++ b/scripts/award_vote.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+# Ensure repository root on path
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+
+from db.DBHelper import register_user, get_money, safe_add_coins
+
+
+def award_vote(user_id: str) -> int:
+    register_user(user_id, user_id)
+    balance = get_money(user_id)
+    if random.random() < 0.01:
+        reward = max(1, int(balance * 0.25))
+    else:
+        ten_percent = int(balance * 0.10)
+        reward = 100 if ten_percent < 100 else random.randint(100, ten_percent)
+    safe_add_coins(user_id, reward)
+    return reward
+
+
+if __name__ == "__main__":
+    uid = sys.argv[1]
+    print(award_vote(uid))


### PR DESCRIPTION
## Summary
- reward voters via webhook using Python helper to add coins
- expose /vote slash command with Top.gg link
- declare express dependency for webhook server

## Testing
- `python -m py_compile scripts/award_vote.py commands/economy_commands.py`
- ❌ `PORT=3001 node server.js` *(fails: Cannot find module 'express'; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b06bed2c8327b87274ad3eb07cfc