### PR TITLE
Add user leveling and XP system

### DIFF
--- a/commands/stats_commands.py
+++ b/commands/stats_commands.py
@@ -25,6 +25,8 @@ from db.DBHelper import (
     set_rod_level,
     get_money,
     set_money,
+    get_level_and_xp,
+    xp_for_next_level,
 )
 
 rod_shop: dict[int, tuple[int, float]] = {}
@@ -67,6 +69,19 @@ def setup(bot: commands.Bot, shop: dict[int, tuple[int, float]]):
         )
         embed.set_footer(text=f"Unspent points: {stats['stat_points']}")
         await interaction.response.send_message(embed=embed, ephemeral=(user is None))
+
+    @bot.tree.command(name="level", description="Show your level and XP")
+    async def level_cmd(
+        interaction: discord.Interaction, user: Optional[discord.Member] = None
+    ):
+        target = user or interaction.user
+        register_user(str(target.id), target.display_name)
+        level, xp = get_level_and_xp(str(target.id))
+        needed = xp_for_next_level(level)
+        await interaction.response.send_message(
+            f"Level {level} – {xp}/{needed} XP",
+            ephemeral=(user is None),
+        )
 
     @bot.tree.command(
         name="quest", description="Complete a short quest to earn stat-points (3?h CD)"

--- a/db/initializeDB.py
+++ b/db/initializeDB.py
@@ -26,7 +26,11 @@ def init_db():
             stat_points INTEGER DEFAULT 0,
             intelligence INTEGER DEFAULT 1,
             strength INTEGER DEFAULT 1,
-            stealth INTEGER DEFAULT 1
+            stealth INTEGER DEFAULT 1,
+            xp INTEGER DEFAULT 0,
+            level INTEGER DEFAULT 1,
+            last_message_xp TEXT,
+            last_weekly TEXT
         )
     """
     )
@@ -275,9 +279,18 @@ def init_db():
         ("intelligence", 1),
         ("strength", 1),
         ("stealth", 1),
+        ("xp", 0),
+        ("level", 1),
+        ("last_message_xp", ""),
     ]:
         if col not in existing:
-            if col in ("last_quest", "last_weekly", "last_fishing", "last_superpower"):
+            if col in (
+                "last_quest",
+                "last_weekly",
+                "last_fishing",
+                "last_superpower",
+                "last_message_xp",
+            ):
                 cursor.execute(f"ALTER TABLE users ADD COLUMN {col} TEXT")
             else:
                 cursor.execute(


### PR DESCRIPTION
## Summary
- Track XP and levels in database
- Award XP for commands and messages with cooldown
- Give coin rewards on each level up and announce them
- Add `/level` command to view progress

## Testing
- `python -m py_compile db/DBHelper.py db/initializeDB.py events.py commands/stats_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68b93e3429f48327b5e116418d7fe028